### PR TITLE
Fix: Broken picture upoaded to oss

### DIFF
--- a/invest_cooker.gemspec
+++ b/invest_cooker.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name      = 'invest_cooker'
-  s.version  = '1.26.10'
+  s.version  = '1.26.11'
   s.date     = '2016-04-12'
   s.summary  = 'Invest cooker cooks hugo invest system.'
   s.homepage = 'https://github.com/TapasTech/InvestCooker'

--- a/lib/utils/image.rb
+++ b/lib/utils/image.rb
@@ -156,12 +156,7 @@ module Utils
           CDNStore.new(url, holder.key)
         end
 
-      # 检查图片是否已存在，存在的图片不进行上传
-      if holder.cdn.exists?
-        return holder.cdn.cdn_url
-      else
-        return holder.upload
-      end
+      return holder.upload
     end
 
     # 通过挂载 OSS volume 上传


### PR DESCRIPTION
当sidekiq被强制重启时，如果已经有正在上传的oss任务，可能会导致阿里云oss可存在不完整的文件。所以每次sidekiq任务重新执行都需要oss文件被重新上传一遍，不能对key做存在性校验（改为对文件摘要做校验也可以）。
